### PR TITLE
accept common_fields.reference_time being a struct

### DIFF
--- a/visualizations/src/data/QlogLoaderV2.ts
+++ b/visualizations/src/data/QlogLoaderV2.ts
@@ -539,7 +539,11 @@ export class DirectEventParser implements IQlogEventParser {
                     return Date.parse( refTimeIn ) * 1000; // only other option is us, so need to do ms * 1000 to get that (small loss of accuracy here)
                 }
         }
-
-        return parseFloat( refTimeIn );
+        else {
+            // Newer draft versions define reference_time as a struct.
+            // This code makes no attempt to parse the struct, but simply prevents us from stumbling over it.
+            const out = parseFloat( refTimeIn );
+            return isNaN(out) ? 0 : out;
+        }
     }
 }


### PR DESCRIPTION
I was implementing the trace header format defined in newer qlog draft versions, but I'm encountering an error as soon as I change the `reference_time` from a string / number to a struct: In that case, qvis complains that the events are not in order, although they are:
```
"QlogLoaderV2:draft02 : timestamps were not in the correct order! NaN  <  -1 
Object { timeTrackingMethod: 1, addTime: NaN, subtractTime: 0, timeMultiplier: 1, _timeOffset: 0, categoryCommon: "unknown", nameCommon: "unknown", _isVue: true, currentEvent: {…} }"
```

Apparently, this is because it fails to parse the timestamp.

This PR makes no attempt to actually parse the struct, or update qvis to the newer draft version. This is the most minimal fix to prevent the parser from stumbling over `reference_time` not being a string.